### PR TITLE
84 teste na minishell

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -94,7 +94,8 @@ char	**ft_create_args(t_shell *blk)
 	//	return (ret = ft_hand_split(blk->buf, "|"));
 	else
 	{
-		blk->tmp = ft_expand(blk, blk->buf);
+		blk->tmp = ft_space_clean(blk->buf, 0, 0, 0);
+		blk->tmp = ft_expand(blk, blk->tmp);
 		if (blk->tmp == NULL)
 			return (NULL); 
 		ret = ft_split_in_spaces(blk->tmp, 0, 0, 0);

--- a/libft/ft_strjoin.c
+++ b/libft/ft_strjoin.c
@@ -15,18 +15,26 @@
 char	*ft_strjoin(char const *s1, char const *s2)
 {
 	char	*temp;
-	int		len2;
 	int		len;
+	int		i;
 
 	if (!s1 || !s2)
-		return (0);
-	len = ft_strlen(s1);
-	len2 = ft_strlen(s2);
-	temp = ft_calloc((len + len2 + 1), sizeof(char));
-	if (temp)
+		return (NULL);
+	len = ft_strlen(s1) + ft_strlen(s2);
+	temp = ft_calloc((len + 1), sizeof(char));
+	if(!temp)
+		return (NULL);
+	len = 0;
+	while(s1[len])
 	{
-		ft_strlcpy(temp, s1, len + 1);
-		ft_strlcat(temp, s2, len + len2 + 1);
+		temp[len] = s1[len];
+		len++;
+	}
+	i = 0;
+	while(s2[i])
+	{
+		temp[len + i] = s2[i];
+		i++;
 	}
 	return (temp);
 }

--- a/libft/ft_strjoinchar.c
+++ b/libft/ft_strjoinchar.c
@@ -15,18 +15,23 @@
 char	*ft_strjoinchar(char const *s1, char s2)
 {
 	char	*temp;
-	int		len2;
 	int		len;
+	int		i;
 
+	i = 0;
 	if (!s1 || !s2)
-		return (0);
+		return (NULL);
 	len = ft_strlen(s1);
-	len2 = 1;
-	temp = ft_calloc((len + len2 + 1), sizeof(char));
-	if (temp)
+	temp = ft_calloc((len + 2), sizeof(char));
+	if (!temp)
+		return (NULL);
+	while(s1[i])
 	{
-		ft_strlcpy(temp, s1, len + 1);
-		ft_strlcat(temp, &s2, len + len2 + 1);
-	}
+		temp[i] = s1[i];
+		i++;
+	}	
+	temp[i] = s2;
+	temp[i + 1] = '\0';
+
 	return (temp);
 }

--- a/libft/ft_substr.c
+++ b/libft/ft_substr.c
@@ -14,15 +14,29 @@
 
 char	*ft_substr(char const *s, unsigned int start, size_t len)
 {
-	char	*temp;
+	char	*substr;
+	size_t	i;
+	size_t	j;
 
 	if (!s)
-		return (0);
-	temp = ft_calloc(len + 1, sizeof(char));
-	if (!temp)
-		return (0);
+		return (NULL);
+	if ((ft_strlen(s) + start) < len)
+		len = ft_strlen(s) + start;
+	i = 0;
 	if (start >= ft_strlen(s))
-		return (temp);
-	ft_strlcpy(temp, &s[start], len + 1);
-	return (temp);
+		return (ft_strdup(""));
+	substr = ft_calloc(sizeof(*s), len + 1);
+	if (!substr)
+		return (NULL);
+	while (i < start)
+		i++;
+	j = 0;
+	while (j < len)
+	{
+		substr[j] = s[i];
+		i++;
+		j++;
+	}
+	substr[j] = '\0';
+	return (substr);
 }

--- a/main.c
+++ b/main.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "lib_mini.h"
+#include "libft/libft.h"
 
 // Separado porque ele sempre vai manter o historico se for comando ou não.
 void	ft_history(char *str)
@@ -48,16 +49,6 @@ int	main(int argc, char **argv, char **envp)
 	signal(SIGINT, signal_handler);
 	signal(SIGQUIT, signal_handler);
 	//ft_access(blk, inp);
-	//printf("%s\n", ft_expand(blk, TESTE));
-	//printf("RESULTADO DO TESTE: %s --\n", ft_var_ret(blk, "ASDAS="));
-	//int i = 0;
-	//char *dirty = "    Va m os     \"ASD      'A'SDA\"   \"\"   testar    ";
-	//char **teste2 = ft_split_in_spaces(dirty, 0, 0, 0);
-	//while(teste2[i] != NULL)
-	//{
-	//	printf("%s\n", teste2[i]);
-	//	i++;
-	//}
 	ft_prompt(blk, inp);
 	ft_freeing(blk->envp);
 	//ft_freeing(teste2);

--- a/parse_utils.c
+++ b/parse_utils.c
@@ -47,22 +47,24 @@ char	*ft_space_clean(char *str, int i, int quote, int space)
 		}
 		i++;
 	}
-	if (ret[ft_strlen(ret) - 1] == ' ')
-		ret[ft_strlen(ret) - 1] = '\0';
+	if (ret[i - 1] == ' ')
+		ret[i - 1] = '\0';
+	else
+		ret[i] = '\0';
 	return (ret);
 }
 
 //essa funcao recebe uma string e splita exatamente nos espacos
 //ela primeiro limpa chamando space clean e depois faz substrings
 //alimentando o char ** de retorno.
-char	**ft_split_in_spaces(char *dirty, int i, int j, int quote)
+char	**ft_split_in_spaces(char *clean, int i, int j, int quote)
 {
 	int		k;
 	char	**ret;
-	char	*clean;
+	//char	*clean;
 
 	k = 0;
-	clean = ft_space_clean(dirty, 0, 0, 0);
+//	clean = ft_space_clean(dirty, 0, 0, 0);
 	ret = ft_calloc(sizeof(char *), ft_find_str(clean, " ") + 2);
 	while (clean[i])
 	{
@@ -77,7 +79,7 @@ char	**ft_split_in_spaces(char *dirty, int i, int j, int quote)
 	}
 	ret[j] = ft_substr(clean, k, i - k);
 	ret[j + 1] = NULL;
-	free(clean);
+//	free(clean);
 	return (ret);
 }
 


### PR DESCRIPTION
Refiz algumas funcoes da lib para nao utilizar Memcpy visto os problemas que isso pode causar e isso resolveu algumas questoes.
Acredito que mais testes precisam ser feitos principalmente com as funcoes que utilizam JOIN, SUBSTR e SPLIT pura.
aqui tudo que testei funciuonou e nao deu problemas a unica coisa foi com n'umeros ou simbolos no final tipo
echo ola 1
ou
echo ola =
com letras no fim aqui funcionou perfeitamente.
isso as vezes da sigabort ou double free.
